### PR TITLE
Search author workaround

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "structlog",
     "typer",
     "selectolax",
+    "click<8.2.0"
 ]
 
 [project.readme]

--- a/src/pygscholar/api/local_db.py
+++ b/src/pygscholar/api/local_db.py
@@ -35,16 +35,25 @@ class LocalNavigator:
 
         print(f"Searching for author {name}")
         query = name.lower().replace(" ", "+")
-        link = f"https://scholar.google.com/citations?view_op=search_authors&hl=en&mauthors={query}"
+        link = f"https://scholar.google.com/scholar?hl=en&as_sdt=0%2C5&q={query}"
+        # link = f"https://scholar.google.com/citations?view_op=search_authors&hl=en&mauthors={query}"
         print(f"Fetching {link}")
         page_source = driver._get_page(link)
         self.insert_page(link, page_source)
+        # scholar_id = (
+        #     LexborHTMLParser(page_source)
+        #     .css(".gs_ai_t")[0]
+        #     .css_first(".gs_ai_name")
+        #     .child.attrs["href"]
+        #     .split("&user=")[-1]
+        # )
+
         scholar_id = (
             LexborHTMLParser(page_source)
-            .css(".gs_ai_t")[0]
-            .css_first(".gs_ai_name")
+            .css(".gs_rt2")[0]
             .child.attrs["href"]
-            .split("&user=")[-1]
+            .split("?user=")[-1]
+            .split("&")[0]
         )
         return scholar_id
 

--- a/src/pygscholar/api/scraper.py
+++ b/src/pygscholar/api/scraper.py
@@ -228,10 +228,52 @@ def search_author(name: str, driver: NavigatorType | None = None) -> list[Author
     query = name.lower().replace(" ", "+")
 
     page_source = driver._get_page(
-        f"https://scholar.google.com/citations?view_op=search_authors&hl=en&mauthors={query}"
+        f"https://scholar.google.com/scholar?hl=en&as_sdt=0%2C5&q={query}"
     )
 
     parser = LexborHTMLParser(page_source)
+
+    authors = []
+    for author in parser.css(".gs_rt2"):
+        name = author.child.text()
+        link = list(author.child.attrs.values())[0]
+        scholar_id = link.split("?user=")[-1].split("&")[0]
+        email = ""
+        cited_by = "0"
+        affiliation = ""
+
+        authors.append(
+            AuthorInfo(
+                name=name,
+                link=link,
+                scholar_id=scholar_id,
+                affiliation=affiliation,
+                email=email,
+                cited_by=cited_by.lstrip("Cited by "),
+            )
+        )
+    logger.debug(f"Found {len(authors)} author(s)")
+
+    return authors
+
+
+# This function does not work anymore because Google Scholar now requires
+# users to be logged in to see the author search results.
+def search_author_orig(name: str, driver: NavigatorType | None = None) -> list[AuthorInfo]:
+    logger.info(f"Searching for author {name}")
+    if driver is None:
+        driver = (
+            Navigator()
+            if not os.getenv("LOCAL_DBPATH")
+            else LocalNavigator(os.getenv("LOCAL_DBPATH"))
+        )
+    query = name.lower().replace(" ", "+")
+
+    page_source = driver._get_page(
+        f"https://scholar.google.com/citations?view_op=search_authors&hl=en&mauthors={query}"
+    )
+    parser = LexborHTMLParser(page_source)
+
     authors = []
     for author in parser.css(".gs_ai_t"):
         name = author.css_first(".gs_ai_name").text()
@@ -309,6 +351,7 @@ def search_author_with_publications(
             ),
         )
     )
+
     info = update_author_info(author, driver=driver)
 
     return Author(info=info, publications=publications)

--- a/src/pygscholar/api/scraper.py
+++ b/src/pygscholar/api/scraper.py
@@ -236,7 +236,7 @@ def search_author(name: str, driver: NavigatorType | None = None) -> list[Author
     authors = []
     for author in parser.css(".gs_rt2"):
         name = author.child.text()
-        link = list(author.child.attrs.values())[0]
+        link = author.child.attrs["href"]
         scholar_id = link.split("?user=")[-1].split("&")[0]
         email = ""
         cited_by = "0"

--- a/src/pygscholar/cli.py
+++ b/src/pygscholar/cli.py
@@ -380,7 +380,7 @@ def generate_test_data(path: Path):
 
 @app.command(help="Download test data")
 def download_test_data(path: Path):
-    link = "https://drive.google.com/uc?id=14VERTNNbU8l-24SDJKkGZqXuHvALtDfI&export=download"
+    link = "https://drive.google.com/uc?id=1cdT3l7dnI8HZ59mv1R0ibNkO7sbos8Zh&export=download"
     import urllib.request
 
     typer.echo(f"Downloading test data from {link} to {path}")


### PR DESCRIPTION
Google scholar now requires users to log in to make author searches. However, the normal search will also list some authors when searching for articles so lets just use that instead. However, this will not be as comprehensive so author searches will not be as good as it was

![Screenshot 2025-05-14 at 10 46 26](https://github.com/user-attachments/assets/83956385-4638-4053-8ba6-8517c51634ee)
 before.

